### PR TITLE
Fix broken skew-symmetry assertion in pfaffian.py

### DIFF
--- a/pfapack/pfaffian.py
+++ b/pfapack/pfaffian.py
@@ -8,6 +8,18 @@ import scipy.linalg as la
 import scipy.sparse as sp
 
 
+def _assert_skew_symmetric(A):
+    """Assert that A is skew-symmetric up to rounding errors at its scale.
+
+    The tolerance is relative to the magnitude of the entries of A, so
+    that matrices with very large or very small entries are handled
+    correctly (an absolute tolerance would spuriously reject large
+    matrices and trivially accept small ones).
+    """
+    tol = 1e-12 * max(1.0, np.abs(A).max())
+    assert np.abs(A + A.T).max() < tol
+
+
 def householder_real(x):
     """(v, tau, alpha) = householder_real(x)
 
@@ -90,7 +102,7 @@ def skew_tridiagonalize(A, overwrite_a=False, calc_q=True):
     # Check if matrix is square
     assert A.shape[0] == A.shape[1] > 0
     # Check if it's skew-symmetric
-    assert abs((A + A.T).max()) < 1e-14
+    _assert_skew_symmetric(A)
 
     A = np.asarray(A)  # the slice views work only properly for arrays
 
@@ -149,7 +161,7 @@ def skew_LTL(A, overwrite_a=False, calc_L=True, calc_P=True):
     # Check if matrix is square
     assert A.shape[0] == A.shape[1] > 0
     # Check if it's skew-symmetric
-    assert abs((A + A.T).max()) < 1e-14
+    _assert_skew_symmetric(A)
 
     n = A.shape[0]
     A = np.asarray(A)  # the slice views work only properly for arrays
@@ -236,7 +248,7 @@ def pfaffian(A, overwrite_a=False, method="P"):
     # Check if matrix is square
     assert A.shape[0] == A.shape[1] > 0
     # Check if it's skew-symmetric
-    assert abs((A + A.T).max()) < 1e-14
+    _assert_skew_symmetric(A)
     # Check that the method variable is appropriately set
     assert method == "P" or method == "H"
 
@@ -257,7 +269,7 @@ def pfaffian_LTL(A, overwrite_a=False):
     # Check if matrix is square
     assert A.shape[0] == A.shape[1] > 0
     # Check if it's skew-symmetric
-    assert abs((A + A.T).max()) < 1e-14
+    _assert_skew_symmetric(A)
 
     n, m = A.shape
     # type check to fix problems with integer numbers
@@ -334,7 +346,7 @@ def pfaffian_householder(A, overwrite_a=False):
     # Check if matrix is square
     assert A.shape[0] == A.shape[1] > 0
     # Check if it's skew-symmetric
-    assert abs((A + A.T).max()) < 1e-14
+    _assert_skew_symmetric(A)
 
     n = A.shape[0]
 
@@ -402,7 +414,7 @@ def pfaffian_schur(A, overwrite_a=False):
 
     assert A.shape[0] == A.shape[1] > 0
 
-    assert abs(A + A.T).max() < 1e-14
+    _assert_skew_symmetric(A)
 
     # Quick return if possible
     if A.shape[0] % 2 == 1:

--- a/pfapack/pfaffian.py
+++ b/pfapack/pfaffian.py
@@ -15,6 +15,9 @@ def _assert_skew_symmetric(A):
     that matrices with very large or very small entries are handled
     correctly (an absolute tolerance would spuriously reject large
     matrices and trivially accept small ones).
+
+    Note that the tolerance is floored at scale 1, so asymmetries
+    smaller than 1e-12 in matrices with entries below ~1 go undetected.
     """
     tol = 1e-12 * max(1.0, np.abs(A).max())
     assert np.abs(A + A.T).max() < tol

--- a/tests/test_pfaffian.py
+++ b/tests/test_pfaffian.py
@@ -75,6 +75,69 @@ def test_decompositions():
     assert numpy.linalg.norm(A - Q * T * Q.T) / numpy.linalg.norm(A) < EPS
 
 
+def test_skew_symmetry_check_negative_deviation():
+    # Regression test: the old check `abs((A + A.T).max()) < 1e-14` only
+    # looked at the largest entry of A + A.T, so a matrix whose deviation
+    # from skew-symmetry is purely *negative* slipped through silently.
+    A = np.array([[0.0, -1.0], [-1.0, 0.0]])  # symmetric, (A + A.T).max() == 0
+
+    for func in (
+        pf.pfaffian,
+        pf.pfaffian_LTL,
+        pf.pfaffian_householder,
+        pf.pfaffian_schur,
+        pf.skew_LTL,
+        pf.skew_tridiagonalize,
+    ):
+        with pytest.raises(AssertionError):
+            func(A)
+
+
+def test_skew_symmetry_check_complex():
+    # The old check compared complex numbers lexicographically (real part
+    # first), which is not a magnitude check; this matrix passed it.
+    A = np.array([[0.0, -1.0 + 1.0j], [-1.0 + 1.0j, 0.0]])
+
+    for func in (
+        pf.pfaffian,
+        pf.pfaffian_LTL,
+        pf.pfaffian_householder,
+        pf.skew_LTL,
+        pf.skew_tridiagonalize,
+    ):
+        with pytest.raises(AssertionError):
+            func(A)
+
+
+def test_skew_symmetry_check_large_scale():
+    # A skew-symmetric matrix with entries ~1e8 carries roundoff of order
+    # 1e-8 in A + A.T; an absolute tolerance would spuriously reject it.
+    A = numpy.random.rand(10, 10)
+    A = (A - A.T) * 1e8
+    # simulate floating-point roundoff at the matrix scale
+    A += numpy.random.standard_normal((10, 10)) * 1e-8
+
+    pfa1 = pf.pfaffian(A)
+    pfa2 = pf.pfaffian(A, method="H")
+    pfa3 = pf.pfaffian_schur(A)
+
+    assert abs((pfa1 - pfa2) / pfa1) < EPS
+    assert abs((pfa1 - pfa3) / pfa1) < EPS
+
+
+def test_skew_symmetry_check_tiny_scale():
+    # A tiny-scaled skew-symmetric matrix must pass the check and yield
+    # the correct (tiny) Pfaffian.
+    A = numpy.random.rand(8, 8)
+    A = (A - A.T) * 1e-12
+
+    pfa1 = pf.pfaffian_LTL(A)
+    pfa2 = pf.pfaffian_householder(A)
+
+    assert pfa1 != 0
+    assert abs((pfa1 - pfa2) / pfa1) < EPS
+
+
 @pytest.mark.skipif(not with_ctypes, reason="the libs might not be installed")
 def test_ctypes():
     for method in ("P", "H"):

--- a/tests/test_pfaffian.py
+++ b/tests/test_pfaffian.py
@@ -112,10 +112,11 @@ def test_skew_symmetry_check_complex():
 def test_skew_symmetry_check_large_scale():
     # A skew-symmetric matrix with entries ~1e8 carries roundoff of order
     # 1e-8 in A + A.T; an absolute tolerance would spuriously reject it.
-    A = numpy.random.rand(10, 10)
+    rng = numpy.random.default_rng(0)
+    A = rng.random((10, 10))
     A = (A - A.T) * 1e8
     # simulate floating-point roundoff at the matrix scale
-    A += numpy.random.standard_normal((10, 10)) * 1e-8
+    A += rng.standard_normal((10, 10)) * 1e-8
 
     pfa1 = pf.pfaffian(A)
     pfa2 = pf.pfaffian(A, method="H")
@@ -128,7 +129,8 @@ def test_skew_symmetry_check_large_scale():
 def test_skew_symmetry_check_tiny_scale():
     # A tiny-scaled skew-symmetric matrix must pass the check and yield
     # the correct (tiny) Pfaffian.
-    A = numpy.random.rand(8, 8)
+    rng = numpy.random.default_rng(0)
+    A = rng.random((8, 8))
     A = (A - A.T) * 1e-12
 
     pfa1 = pf.pfaffian_LTL(A)


### PR DESCRIPTION
Addresses the broken skew-symmetry check also fixed in #8.

## Problem

Every public function in `pfapack/pfaffian.py` validated its input with:

```python
assert abs((A + A.T).max()) < 1e-14
```

This check is buggy in two ways:

1. **`.max()` runs before `abs()`** — a matrix violating skew-symmetry with a purely *negative* deviation (e.g. a symmetric matrix with negative off-diagonal entries, where `(A + A.T).max()` is 0) passed silently and produced a wrong Pfaffian.
2. **For complex matrices**, `.max()` compares lexicographically (real part first), which is not a meaningful magnitude check.

## Fix

All 6 sites (`skew_tridiagonalize`, `skew_LTL`, `pfaffian`, `pfaffian_LTL`, `pfaffian_householder`, `pfaffian_schur`) now call a shared `_assert_skew_symmetric(A)` helper:

```python
tol = 1e-12 * max(1.0, np.abs(A).max())
assert np.abs(A + A.T).max() < tol
```

The tolerance is **relative to the matrix scale** rather than absolute: a matrix with entries ~1e8 carries floating-point roundoff of order 1e-8 in `A + A.T` and would be spuriously rejected by an absolute tolerance, while a tiny-scaled matrix would pass any absolute check trivially. The check still raises `AssertionError`, so the public behavior contract is unchanged.

## Tests

Four regression tests covering the blind spots:

- a symmetric real matrix with `(A + A.T).max() == 0` (old negative-deviation blind spot) raises in all six functions
- a non-skew complex matrix that passed the old lexicographic comparison raises
- a valid skew-symmetric matrix at scale 1e8 with roundoff-level asymmetry passes, and all three Pfaffian methods agree
- a valid skew-symmetric matrix at scale 1e-12 passes and returns the correct tiny Pfaffian (`pfaffian_LTL` vs `pfaffian_householder` cross-check)

## Credit

The bug was identified in the [jjgoings/pfapack](https://github.com/jjgoings/pfapack) fork by Joshua Goings.
