### PR TITLE
Fix Build Wheels CI: sdist BLAS dependency and Windows toolchain

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           submodules: recursive
 
+      # meson-python configures the project even for an sdist build,
+      # and meson.build requires BLAS/LAPACK and a Fortran compiler
+      - name: Install OpenBLAS
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev gfortran
+
       - name: Build SDist
         run: pipx run build --sdist
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,7 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # On Windows the MSYS2 toolchain below is used instead; the gcc that
+      # this action installs via chocolatey cannot find its own headers
+      # (fatal error: stdlib.h) when invoked through the chocolatey shims.
       - uses: fortran-lang/setup-fortran@v1
+        if: runner.os != 'Windows'
         id: setup-fortran
         with:
           version: 12 # should be available on all runners
@@ -34,6 +38,13 @@ jobs:
             mingw-w64-x86_64-openblas
           path-type: minimal
           release: false
+
+      # Make the MSYS2 gcc/gfortran/OpenBLAS visible to cibuildwheel;
+      # meson.build already searches C:/msys64/mingw64/lib for OpenBLAS
+      - name: Add MSYS2 MinGW64 to PATH (Windows)
+        if: runner.os == 'Windows'
+        run: echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
+        shell: bash
 
       # https://github.com/pypa/cibuildwheel/issues/563
       - name: Set macOS deployment target

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,10 +34,11 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
+          # pkgconf lets meson find openblas.pc, skipping its flaky CMake probe
           install: >-
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-pkgconf  # lets meson find openblas.pc, skipping its flaky CMake probe
+            mingw-w64-x86_64-pkgconf
           path-type: minimal
           release: false
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        # macos-15-intel: GitHub retired the macos-13 runners; jobs queued forever
+        os: [ubuntu-latest, macos-15-intel, macos-14, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +37,7 @@ jobs:
           install: >-
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-pkgconf  # lets meson find openblas.pc, skipping its flaky CMake probe
           path-type: minimal
           release: false
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,6 +36,7 @@ jobs:
           install: >-
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
+            mingw-w64-x86_64-pkgconf
           path-type: minimal
           release: false
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,7 +66,9 @@ jobs:
     - name: Build and run C/Fortran tests
       run: |
         # Install and run tests
-        pip install -U meson pip ninja
+        # (python -m pip: on Windows pip.exe refuses to upgrade itself
+        # and aborts the whole install, leaving meson missing)
+        python -m pip install -U meson pip ninja
         pip install -e . --config-settings=setup-args="-Dbuild_tests=enabled"
         cd build/cp* && meson test --verbose
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,7 +27,11 @@ jobs:
       with:
         python-version: "${{ matrix.python-version }}"
 
+    # On Windows the MSYS2 toolchain below is used instead; the gcc that
+    # this action installs via chocolatey cannot find its own headers
+    # (fatal error: stdlib.h) when invoked through the chocolatey shims.
     - uses: fortran-lang/setup-fortran@v1
+      if: runner.os != 'Windows'
       id: setup-fortran
       with:
         version: 12 # should be available on all runners
@@ -49,6 +53,12 @@ jobs:
           mingw-w64-x86_64-openblas
         path-type: minimal
         release: false
+
+    # Make the MSYS2 gcc/gfortran/OpenBLAS visible to the build;
+    # meson.build already searches C:/msys64/mingw64/lib for OpenBLAS
+    - name: Add MSYS2 MinGW64 to PATH (Windows)
+      if: runner.os == 'Windows'
+      run: echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
 
     # NOTE: No MacOS specific install.
     # We'll use the Accelerate framework instead of installing BLAS/LAPACK

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,10 +48,11 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
+        # pkgconf lets meson find openblas.pc, skipping its flaky CMake probe
         install: >-
           mingw-w64-x86_64-gcc-fortran
           mingw-w64-x86_64-openblas
-          mingw-w64-x86_64-pkgconf  # lets meson find openblas.pc, skipping its flaky CMake probe
+          mingw-w64-x86_64-pkgconf
         path-type: minimal
         release: false
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,6 +51,7 @@ jobs:
         install: >-
           mingw-w64-x86_64-gcc-fortran
           mingw-w64-x86_64-openblas
+          mingw-w64-x86_64-pkgconf
         path-type: minimal
         release: false
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
         install: >-
           mingw-w64-x86_64-gcc-fortran
           mingw-w64-x86_64-openblas
-          mingw-w64-x86_64-pkgconf
+          mingw-w64-x86_64-pkgconf  # lets meson find openblas.pc, skipping its flaky CMake probe
         path-type: minimal
         release: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,7 @@ skip = [
 ]
 
 [tool.cibuildwheel.linux]
+# manylinux2014's glibc 2.17 is too old to install current scipy wheels
+# (manylinux_2_27+) in the test environment, forcing a doomed source build
+manylinux-x86_64-image = "manylinux_2_28"
 before-all = "yum install -y openblas-devel"


### PR DESCRIPTION
Two fixes for the long-red "Build Wheels" workflow (every one of the last 40 completed runs failed).

## 1. sdist job: missing BLAS

```
../meson.build:54:28: ERROR: C shared or static library 'blas' not found
```

meson-python runs `meson setup` even when only building an sdist, and `meson.build` hard-requires BLAS/LAPACK (and a Fortran compiler) at configure time on Linux. The `build_sdist` job ran `pipx run build --sdist` on a bare `ubuntu-latest` runner. Fix: install `libopenblas-dev` and `gfortran` first. **Verified green on this PR's first CI run.**

## 2. Windows wheel job: broken gcc from chocolatey

```
../original_source/c_interface/commondefs.h:15:10: fatal error: stdlib.h: No such file or directory
```

meson picked up the gcc that `fortran-lang/setup-fortran` installs via chocolatey, and through the chocolatey shims that compiler cannot find its own standard headers. The action also hangs intermittently mid-install (this PR's first run sat in that step for over an hour).

The job already installs a coherent MinGW64 toolchain (`mingw-w64-x86_64-gcc-fortran` + `mingw-w64-x86_64-openblas`) via `msys2/setup-msys2`, and `meson.build` already searches `C:/msys64/mingw64/lib` for OpenBLAS — it just was never on `PATH` for cibuildwheel (`path-type: minimal` keeps it out of the global environment). Fix: skip `setup-fortran` on Windows and add `C:/msys64/mingw64/bin` to `GITHUB_PATH` instead.