### PR TITLE
Bundle OpenBLAS into Windows wheels with delvewheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,6 +62,28 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
+      # The cibuildwheel tests above run with MSYS2 on PATH (and ctypes.py
+      # falls back to hardcoded C:/msys64 paths), so they cannot detect a
+      # wheel that fails to bundle its DLLs. Hide MSYS2 and run the test
+      # suite against the repaired wheel in a clean environment.
+      - uses: actions/setup-python@v5
+        if: runner.os == 'Windows'
+        with:
+          python-version: "3.13"
+
+      - name: Check wheel is self-contained (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Rename-Item C:/msys64 msys64-hidden
+          python -m venv $env:RUNNER_TEMP/verify-venv
+          & "$env:RUNNER_TEMP/verify-venv/Scripts/python" -m pip install pytest pytest-cov
+          $wheel = Get-ChildItem wheelhouse -Filter "*cp313*win_amd64.whl" | Select-Object -First 1
+          & "$env:RUNNER_TEMP/verify-venv/Scripts/python" -m pip install $wheel.FullName
+          Set-Location $env:RUNNER_TEMP
+          & "$env:RUNNER_TEMP/verify-venv/Scripts/python" -m pytest --import-mode=importlib "$env:GITHUB_WORKSPACE/tests"
+
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Windows wheels are now repaired with `delvewheel`, bundling OpenBLAS and the
+  MinGW runtime DLLs. Installing from PyPI no longer requires MSYS2; only
+  building from source on Windows does. CI verifies the wheel is
+  self-contained by running the test suite with MSYS2 hidden.
+
 ## [1.1.0] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ pfa2 = cpf(A, method="H")
 print(pfa1, pfa2)
 ```
 
-> [!WARNING]
-> On Windows, the C bindings require MSYS2 to be installed with the MinGW64 toolchain. The current Windows build system has some limitations and requires external dependencies. We welcome contributions to improve the Windows build system, such as using Microsoft's toolchain (MSVC) directly or finding better ways to handle the OpenBLAS dependency.
+> [!NOTE]
+> The Windows wheels on PyPI bundle OpenBLAS and the MinGW runtime, so `pip install pfapack` works without any external dependencies. Building from source on Windows still requires MSYS2 with the MinGW64 toolchain (`mingw-w64-x86_64-gcc-fortran`, `mingw-w64-x86_64-openblas`, and `mingw-w64-x86_64-pkgconf`). We welcome contributions to improve the Windows build system, such as using Microsoft's toolchain (MSVC) directly.
 
 ## Citing
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ print(pfa1, pfa2)
 ```
 
 > [!NOTE]
-> The Windows wheels on PyPI bundle OpenBLAS and the MinGW runtime, so `pip install pfapack` works without any external dependencies. Building from source on Windows still requires MSYS2 with the MinGW64 toolchain (`mingw-w64-x86_64-gcc-fortran`, `mingw-w64-x86_64-openblas`, and `mingw-w64-x86_64-pkgconf`). We welcome contributions to improve the Windows build system, such as using Microsoft's toolchain (MSVC) directly.
+> Building from source on Windows (only needed if no wheel is available for your platform) requires MSYS2 with the MinGW64 toolchain (`mingw-w64-x86_64-gcc-fortran`, `mingw-w64-x86_64-openblas`, and `mingw-w64-x86_64-pkgconf`).
 
 ## Citing
 

--- a/pfapack/ctypes.py
+++ b/pfapack/ctypes.py
@@ -29,7 +29,14 @@ def _find_library() -> ctypes.CDLL:
 
     # On Windows, ensure OpenBLAS and its dependencies can be found
     if os.name == "nt":
-        # Common locations for OpenBLAS on Windows
+        # Wheels repaired with delvewheel bundle OpenBLAS and the MinGW
+        # runtime in pfapack.libs; no system installation is needed.
+        _bundled = _folder.parent / "pfapack.libs"
+        if _bundled.exists():
+            os.add_dll_directory(str(_bundled))  # type: ignore[attr-defined]
+            return _load_pfapack_dll(_folder, _build_folder)
+
+        # Source builds: hunt for a system OpenBLAS.
         possible_blas_paths = [
             Path("C:/msys64/mingw64/bin"),  # MSYS2 MinGW64
             Path("C:/msys64/ucrt64/bin"),  # MSYS2 UCRT64
@@ -56,6 +63,11 @@ def _find_library() -> ctypes.CDLL:
         if not blas_loaded:
             print("Warning: Could not load OpenBLAS from any known location")
 
+    return _load_pfapack_dll(_folder, _build_folder)
+
+
+def _load_pfapack_dll(_folder: Path, _build_folder: Path) -> ctypes.CDLL:
+    """Load the PFAPACK C library from the package or build directory."""
     # Try all possible library names
     lib_names = [
         "cpfapack.dll",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,10 @@ before-build = "pip install delvewheel meson-python"
 # from PyPI works without MSYS2. --analyze-existing is required because the
 # pfapack libraries are plain DLLs loaded via ctypes, not extension modules,
 # which delvewheel would otherwise not scan for dependencies.
-repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --add-path C:/msys64/mingw64/bin --analyze-existing"
+# --ignore-existing stops delvewheel from treating the intra-wheel dependency
+# of libcpfapack.dll on libpfapack.dll as missing; it resolves at runtime from
+# the package directory.
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --add-path C:/msys64/mingw64/bin --analyze-existing --ignore-existing"
 
 [tool.cibuildwheel.linux]
 # manylinux2014's glibc 2.17 is too old to install current scipy wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,14 @@ skip = [
     "cp39-*",       # Skip Python 3.9
 ]
 
+[tool.cibuildwheel.windows]
+before-build = "pip install delvewheel meson-python"
+# Bundle OpenBLAS and the MinGW runtime DLLs into the wheel so that installing
+# from PyPI works without MSYS2. --analyze-existing is required because the
+# pfapack libraries are plain DLLs loaded via ctypes, not extension modules,
+# which delvewheel would otherwise not scan for dependencies.
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --add-path C:/msys64/mingw64/bin --analyze-existing"
+
 [tool.cibuildwheel.linux]
 # manylinux2014's glibc 2.17 is too old to install current scipy wheels
 # (manylinux_2_27+) in the test environment, forcing a doomed source build


### PR DESCRIPTION
## Problem

Windows wheels link against the MSYS2 MinGW64 OpenBLAS and gfortran runtime DLLs but don't bundle them, so `pip install pfapack` on Windows requires a full MSYS2 installation at runtime for the C bindings to work (`ctypes.py` hunts for `libopenblas.dll` in hardcoded `C:/msys64/*` paths). This is the runtime half of the README's Windows warning.

## Changes

- **`pyproject.toml`**: add `[tool.cibuildwheel.windows]` that repairs wheels with `delvewheel`, vendoring OpenBLAS and the MinGW runtime DLLs into `pfapack.libs`. `--analyze-existing` is required because the pfapack libraries are plain DLLs loaded via ctypes, not extension modules, which delvewheel does not scan by default.
- **`pfapack/ctypes.py`**: prefer the bundled `pfapack.libs` directory when present; the system OpenBLAS hunt (MSYS2/conda/`OPENBLAS_PATH`) remains as the fallback for source builds.
- **`.github/workflows/build_wheels.yml`**: the cibuildwheel tests run with MSYS2 on PATH (and ctypes.py falls back to hardcoded `C:/msys64` paths), so they cannot detect a wheel that fails to bundle its DLLs. Add a Windows step that renames `C:/msys64` away, installs the cp313 wheel into a fresh venv, and runs the test suite.
- **`README.md`**: downgrade the warning to a note — pip wheels are now self-contained; only building from source needs MSYS2.
- **`CHANGELOG.md`**: add `[Unreleased]` entry.

## Notes

- Building from source on Windows still uses the MSYS2 MinGW64 toolchain; switching to MSVC is out of scope (no Fortran compiler there).
- Known possible failure mode: delvewheel mangles DLL names by default and occasionally refuses on MinGW DLLs with exported data symbols (OpenBLAS is a known offender). If the repair step fails on that, the fix is adding `--no-mangle-all` to the repair command — safe here since nothing else in the process loads these copies.