### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.1] - 2026-06-10
 
 ### Changed
 - Windows wheels are now repaired with `delvewheel`, bundling OpenBLAS and the
   MinGW runtime DLLs. Installing from PyPI no longer requires MSYS2; only
   building from source on Windows does. CI verifies the wheel is
   self-contained by running the test suite with MSYS2 hidden.
+  ([#55](https://github.com/basnijholt/pfapack/pull/55))
 
 ## [1.1.0] - 2026-06-10
 
@@ -88,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix for integer valued arrays.
 
+[1.1.1]: https://github.com/basnijholt/pfapack/releases/tag/v1.1.1
 [1.1.0]: https://github.com/basnijholt/pfapack/releases/tag/v1.1.0
 [1.0.2]: https://github.com/basnijholt/pfapack/releases/tag/v1.0.2
 [1.0.1]: https://github.com/basnijholt/pfapack/releases/tag/v1.0.1


### PR DESCRIPTION
Prepare the v1.1.1 release: move the `[Unreleased]` changelog entry to `[1.1.1]` with a link to #55.

The only change since v1.1.0 is the delvewheel bundling of OpenBLAS and the MinGW runtime into the Windows wheels (#55), so `pip install pfapack` on Windows no longer requires MSYS2.

After merging, tag the merge commit to trigger the PyPI upload:

```bash
git checkout main && git pull
git tag v1.1.1
git push origin v1.1.1
```