### PR TITLE
Add batched Pfaffian computation (pfaffian_batched)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ pfa2 = cpf(A, method="H")
 print(pfa1, pfa2)
 ```
 
+For many small matrices, use the batched interface, which is significantly
+faster than looping because workspace is allocated once per batch:
+```python
+import numpy
+from pfapack.ctypes import pfaffian_batched
+
+matrices = numpy.random.rand(1000, 8, 8)
+matrices = matrices - matrices.transpose(0, 2, 1)
+pfaffians = pfaffian_batched(matrices)  # shape (1000,)
+```
+
 > [!NOTE]
 > Building from source on Windows (only needed if no wheel is available for your platform) requires MSYS2 with the MinGW64 toolchain (`mingw-w64-x86_64-gcc-fortran`, `mingw-w64-x86_64-openblas`, and `mingw-w64-x86_64-pkgconf`).
 

--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,7 @@ fortran_sources = files(
 # C sources
 c_sources = files(
   join_paths(pfapack_dir, 'c_interface', 'skpfa.c'),
+  join_paths(pfapack_dir, 'c_interface', 'skpfa_batched.c'),
   join_paths(pfapack_dir, 'c_interface', 'skpf10.c'),
   join_paths(pfapack_dir, 'c_interface', 'skbpfa.c'),
   join_paths(pfapack_dir, 'c_interface', 'skbpf10.c'),

--- a/original_source/c_interface/pfapack.h
+++ b/original_source/c_interface/pfapack.h
@@ -14,6 +14,11 @@ int skpfa_c(int, floatcmplx *, floatcmplx *,
 int skpfa_z(int, doublecmplx *, doublecmplx *,
 	    const char *, const char *);
 
+int skpfa_batched_d(int, int, const double *, double *,
+		    const char *, const char *);
+int skpfa_batched_z(int, int, const doublecmplx *, doublecmplx *,
+		    const char *, const char *);
+
 int skpf10_s(int, float *, float *, const char *, const char *);
 int skpf10_d(int, double *, double *, const char *, const char *);
 int skpf10_c(int, floatcmplx *, floatcmplx *,

--- a/original_source/c_interface/skpfa_batched.c
+++ b/original_source/c_interface/skpfa_batched.c
@@ -1,0 +1,266 @@
+/**********************************************************************
+  Purpose
+  =======
+
+  skpfa_batched_x computes the Pfaffians of a batch of dense
+  skew-symmetric matrices. Compared to calling skpfa_x in a loop, the
+  LAPACK workspace is allocated once for the whole batch rather than
+  once per matrix, which significantly reduces overhead for batches of
+  many small matrices.
+
+  Usage
+  =====
+
+  int skpfa_batched_x(int BATCH_SIZE, int N, const datatype *A_BATCH,
+                      datatype *PFAFF_BATCH, const char *UPLO,
+                      const char *MTHD)
+
+  where
+     datatype = double or doublecmplx
+  for x = d or z
+
+  Arguments
+  =========
+
+  BATCH_SIZE (input) int
+          Number of matrices in the batch. BATCH_SIZE >= 0.
+
+  N       (input) int
+          Size of each matrix. N >= 0.
+
+  A_BATCH (input) datatype *
+          pointer to a memory block of size
+          BATCH_SIZE*N*N*sizeof(datatype) holding BATCH_SIZE
+          consecutive skew-symmetric NxN-matrices in C format
+          (row-major order). Note that this differs from skpfa_x,
+          which expects Fortran format. The input is not modified.
+             If UPLO = 'U', the upper triangular part of each matrix
+                contains its upper triangular part, and the strictly
+                lower triangular part is not referenced.
+             If UPLO = 'L', vice versa.
+
+  PFAFF_BATCH (output) datatype *
+          pointer to a memory block of size BATCH_SIZE*sizeof(datatype)
+          The values of the Pfaffians.
+
+  UPLO    (input) char *
+            = 'U':  Upper triangle of each matrix is stored;
+            = 'L':  Lower triangle of each matrix is stored.
+
+  MTHD    (input) char *
+            = 'P': Compute Pfaffian using Parlett-Reid algorithm
+                   (recommended)
+            = 'H': Compute Pfaffian using Householder reflections
+
+  Return value
+  ============
+
+  The return value indicates whether an error occured:
+      0:    successful exit
+    < 0:    if the return value is -i, the i-th argument had an
+            illegal value
+   -100:    failed to allocate enough internal memory
+
+  Further Details
+  ===============
+
+  The row-major matrices are fed directly to the column-major Fortran
+  kernels without transposing: the kernel then operates on A^T rather
+  than A. This is accounted for by swapping UPLO and using the identity
+  pf(A^T) = pf(-A) = (-1)^(N/2) pf(A) to correct the sign of the
+  result, avoiding an explicit transpose of every matrix in the batch.
+
+  Ported from the batched implementation by Joshua Goings (@jjgoings),
+  https://github.com/jjgoings/pfapack.
+
+****************************************************************************/
+
+#include <string.h>
+
+#include "commondefs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int skpfa_batched_d(int batch_size, int N,
+                    const double *A_batch, double *PFAFF_batch,
+                    const char *UPLO, const char *MTHD)
+{
+    char uplo = toupper(UPLO[0]);
+    char mthd = toupper(MTHD[0]);
+    int i, info = 0, ret = 0;
+
+    if (batch_size < 0) return -1;
+    if (N < 0) return -2;
+    if (A_batch == NULL) return -3;
+    if (PFAFF_batch == NULL) return -4;
+    if (uplo != 'U' && uplo != 'L') return -5;
+    if (mthd != 'P' && mthd != 'H') return -6;
+
+    if (N == 0) {
+        for (i = 0; i < batch_size; i++) PFAFF_batch[i] = 1.0;
+        return 0;
+    }
+
+    /* Row-major input read as column-major is A^T, whose data lives in
+       the opposite triangle; the sign is fixed up after the fact. */
+    {
+        const char uplo_t = (uplo == 'U') ? 'L' : 'U';
+        const int sign_flip = (N / 2) % 2;
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        int ldim = N, lwork = -1;
+        double qwork = 0.0, pfaff_dummy = 0.0;
+        double *work;
+
+        double *A_work = (double *)malloc(matrix_elems * sizeof(double));
+        int *iwork = (int *)malloc((size_t)N * sizeof(int));
+        if (!A_work || !iwork) {
+            free(iwork);
+            free(A_work);
+            return -100;
+        }
+
+        /* Workspace query, done once for the whole batch */
+        PFAPACK_dskpfa(&uplo_t, &mthd, &N, A_work, &ldim, &pfaff_dummy,
+                       iwork, &qwork, &lwork, &info);
+        if (info) {
+            free(iwork);
+            free(A_work);
+            return info;
+        }
+
+        lwork = (int)qwork;
+        if (lwork < 1) lwork = 1;
+        work = (double *)malloc((size_t)lwork * sizeof(double));
+        if (!work) {
+            /* Fall back to the minimal workspace */
+            lwork = (mthd == 'P') ? 1 : (2 * N - 1);
+            work = (double *)malloc((size_t)lwork * sizeof(double));
+            if (!work) {
+                free(iwork);
+                free(A_work);
+                return -100;
+            }
+        }
+
+        for (i = 0; i < batch_size; i++) {
+            memcpy(A_work, A_batch + (size_t)i * matrix_elems,
+                   matrix_elems * sizeof(double));
+            PFAPACK_dskpfa(&uplo_t, &mthd, &N, A_work, &ldim,
+                           &PFAFF_batch[i], iwork, work, &lwork, &info);
+            if (info) {
+                ret = info;
+                break;
+            }
+            if (sign_flip) PFAFF_batch[i] = -PFAFF_batch[i];
+        }
+
+        free(work);
+        free(iwork);
+        free(A_work);
+    }
+
+    return ret;
+}
+
+int skpfa_batched_z(int batch_size, int N,
+                    const doublecmplx *A_batch, doublecmplx *PFAFF_batch,
+                    const char *UPLO, const char *MTHD)
+{
+    char uplo = toupper(UPLO[0]);
+    char mthd = toupper(MTHD[0]);
+    int i, info = 0, ret = 0;
+
+    if (batch_size < 0) return -1;
+    if (N < 0) return -2;
+    if (A_batch == NULL) return -3;
+    if (PFAFF_batch == NULL) return -4;
+    if (uplo != 'U' && uplo != 'L') return -5;
+    if (mthd != 'P' && mthd != 'H') return -6;
+
+    if (N == 0) {
+        for (i = 0; i < batch_size; i++) PFAFF_batch[i] = doublecmplx_one;
+        return 0;
+    }
+
+    /* Row-major input read as column-major is A^T, whose data lives in
+       the opposite triangle; the sign is fixed up after the fact. */
+    {
+        const char uplo_t = (uplo == 'U') ? 'L' : 'U';
+        const int sign_flip = (N / 2) % 2;
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        int ldim = N, lwork = -1;
+        doublecmplx qwork = doublecmplx_zero;
+        doublecmplx pfaff_dummy = doublecmplx_zero;
+        doublecmplx *work;
+        double *rwork;
+
+        doublecmplx *A_work =
+            (doublecmplx *)malloc(matrix_elems * sizeof(doublecmplx));
+        int *iwork = (int *)malloc((size_t)N * sizeof(int));
+        rwork = (double *)malloc((size_t)(N > 1 ? N - 1 : 1) * sizeof(double));
+        if (!A_work || !iwork || !rwork) {
+            free(rwork);
+            free(iwork);
+            free(A_work);
+            return -100;
+        }
+
+        /* Workspace query, done once for the whole batch */
+        PFAPACK_zskpfa(&uplo_t, &mthd, &N, A_work, &ldim, &pfaff_dummy,
+                       iwork, &qwork, &lwork, rwork, &info);
+        if (info) {
+            free(rwork);
+            free(iwork);
+            free(A_work);
+            return info;
+        }
+
+        lwork = (int)real(qwork);
+        if (lwork < 1) lwork = 1;
+        work = (doublecmplx *)malloc((size_t)lwork * sizeof(doublecmplx));
+        if (!work) {
+            /* Fall back to the minimal workspace */
+            lwork = (mthd == 'P') ? 1 : (2 * N - 1);
+            work = (doublecmplx *)malloc((size_t)lwork * sizeof(doublecmplx));
+            if (!work) {
+                free(rwork);
+                free(iwork);
+                free(A_work);
+                return -100;
+            }
+        }
+
+        for (i = 0; i < batch_size; i++) {
+            memcpy(A_work, A_batch + (size_t)i * matrix_elems,
+                   matrix_elems * sizeof(doublecmplx));
+            PFAPACK_zskpfa(&uplo_t, &mthd, &N, A_work, &ldim,
+                           &PFAFF_batch[i], iwork, work, &lwork, rwork,
+                           &info);
+            if (info) {
+                ret = info;
+                break;
+            }
+#ifdef STRUCT_COMPLEX
+            if (sign_flip) {
+                PFAFF_batch[i].re = -PFAFF_batch[i].re;
+                PFAFF_batch[i].im = -PFAFF_batch[i].im;
+            }
+#else
+            if (sign_flip) PFAFF_batch[i] = -PFAFF_batch[i];
+#endif
+        }
+
+        free(work);
+        free(rwork);
+        free(iwork);
+        free(A_work);
+    }
+
+    return ret;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/pfapack/ctypes.py
+++ b/pfapack/ctypes.py
@@ -128,10 +128,26 @@ def _init(which):
     return func
 
 
+def _init_batched(which, dtype):
+    func = getattr(lib, which)
+    func.restype = ctypes.c_int  # result type
+    func.argtypes = [
+        ctypes.c_int,  # batch_size
+        ctypes.c_int,  # N
+        ndpointer(dtype, flags="C_CONTIGUOUS"),  # A_batch
+        ndpointer(dtype, flags="C_CONTIGUOUS"),  # PFAFF_batch
+        ctypes.c_char_p,  # UPLO
+        ctypes.c_char_p,  # MTHD
+    ]
+    return func
+
+
 skpfa_d = _init("skpfa_d")  # Pfaffian for real double
 skpf10_d = _init("skpf10_d")
 skpfa_z = _init("skpfa_z")  # Pfaffian for complex double
 skpf10_z = _init("skpf10_z")
+skpfa_batched_d = _init_batched("skpfa_batched_d", np.float64)
+skpfa_batched_z = _init_batched("skpfa_batched_z", np.complex128)
 
 
 def from_exp(x, exp):
@@ -239,3 +255,80 @@ def pfaffian(
     if success != 0:
         raise ComputationError(f"PFAPACK returned error code {success}")
     return result
+
+
+def pfaffian_batched(
+    matrices: np.ndarray,
+    uplo: str = "U",
+    method: str = "P",
+) -> np.ndarray:
+    """Compute the Pfaffian of a batch of skew-symmetric matrices.
+
+    Equivalent to calling :func:`pfaffian` on every matrix, but much
+    faster for batches of many small matrices because the LAPACK
+    workspace is allocated once for the whole batch.
+
+    Ported from the batched implementation by Joshua Goings (@jjgoings),
+    https://github.com/jjgoings/pfapack.
+
+    Parameters
+    ----------
+    matrices : numpy.ndarray
+        Array of shape ``(..., N, N)`` holding skew-symmetric matrices.
+        Real input is computed in double precision, complex input in
+        complex double precision; other dtypes are upcast.
+    uplo : str
+        If 'U' ('L'), the upper (lower) triangle of each matrix is used.
+    method : str
+        If 'P' ('H'), the Parley-Reid (Householder) algorithm is used.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(...,)`` with the Pfaffian of each matrix
+        (a scalar if a single 2D matrix was passed). For matrices of
+        odd dimension the Pfaffian is 0.
+
+    Raises
+    ------
+    InvalidDimensionError
+        If the input is not an array of square matrices.
+    InvalidParameterError
+        If uplo or method parameters are invalid.
+    ComputationError
+        If the computation fails.
+    """
+    if uplo not in ("U", "L"):
+        raise InvalidParameterError(f"'uplo' must be 'U' or 'L', got {uplo!r}")
+    if method not in ("P", "H"):
+        raise InvalidParameterError(f"'method' must be 'P' or 'H', got {method!r}")
+
+    matrices = np.asarray(matrices)
+    if matrices.ndim < 2 or matrices.shape[-1] != matrices.shape[-2]:
+        raise InvalidDimensionError(
+            "Expected an array of square matrices with shape (..., N, N), "
+            f"got shape {matrices.shape}"
+        )
+
+    n = matrices.shape[-1]
+    batch_shape = matrices.shape[:-2]
+    batch_size = int(np.prod(batch_shape, dtype=np.int64))
+
+    if np.iscomplexobj(matrices):
+        dtype = np.complex128
+        func = skpfa_batched_z
+    else:
+        dtype = np.float64
+        func = skpfa_batched_d
+
+    # Copies only if the dtype or memory layout requires it.
+    a = np.ascontiguousarray(matrices, dtype=dtype).reshape(batch_size, n, n)
+    pfaffians = np.empty(batch_size, dtype=dtype)
+
+    if batch_size > 0:
+        success = func(batch_size, n, a, pfaffians, uplo.encode(), method.encode())
+        if success != 0:
+            raise ComputationError(f"PFAPACK returned error code {success}")
+
+    # For 2D input batch_shape is (), so this returns a scalar.
+    return pfaffians.reshape(batch_shape)[()]

--- a/tests/test_ctypes_batched.py
+++ b/tests/test_ctypes_batched.py
@@ -1,0 +1,164 @@
+"""Tests for the batched Pfaffian interface (pfapack.ctypes.pfaffian_batched)."""
+
+import numpy as np
+import pytest
+
+from pfapack import pfaffian as pf
+from pfapack.exceptions import InvalidDimensionError, InvalidParameterError
+
+try:
+    from pfapack.ctypes import pfaffian as cpfaffian
+    from pfapack.ctypes import pfaffian_batched
+
+    with_ctypes = True
+except OSError:
+    with_ctypes = False
+
+pytestmark = pytest.mark.skipif(not with_ctypes, reason="C library not available")
+
+EPS = 1e-11
+
+
+def make_skew(batch_shape, n, complex_, seed=0):
+    rng = np.random.default_rng(seed)
+    a = rng.standard_normal(batch_shape + (n, n))
+    if complex_:
+        a = a + 1j * rng.standard_normal(batch_shape + (n, n))
+    return a - np.swapaxes(a, -1, -2)
+
+
+# N=6 and N=10 have odd N/2, exercising the (-1)^(N/2) sign correction
+# of the internal transpose-elimination trick.
+@pytest.mark.parametrize("n", [2, 4, 6, 8, 10])
+@pytest.mark.parametrize("complex_", [False, True])
+@pytest.mark.parametrize("method", ["P", "H"])
+def test_matches_single_matrix(n, complex_, method):
+    matrices = make_skew((7,), n, complex_, seed=n)
+    result = pfaffian_batched(matrices, method=method)
+
+    expected_c = np.array([cpfaffian(m, method=method) for m in matrices])
+    expected_py = np.array([pf.pfaffian(m, method=method) for m in matrices])
+
+    np.testing.assert_allclose(result, expected_c, rtol=EPS, atol=EPS)
+    np.testing.assert_allclose(result, expected_py, rtol=EPS, atol=EPS)
+
+
+@pytest.mark.parametrize("complex_", [False, True])
+def test_uplo_lower(complex_):
+    matrices = make_skew((5,), 6, complex_, seed=42)
+    np.testing.assert_allclose(
+        pfaffian_batched(matrices, uplo="L"),
+        pfaffian_batched(matrices, uplo="U"),
+        rtol=EPS,
+        atol=EPS,
+    )
+
+
+def test_known_values():
+    block = np.array([[0.0, 1.0], [-1.0, 0.0]])
+    batch = np.array([block, 2 * block, -3 * block])
+    np.testing.assert_allclose(
+        pfaffian_batched(batch), [1.0, 2.0, -3.0], rtol=EPS, atol=EPS
+    )
+
+
+@pytest.mark.parametrize("n", [1, 3, 5])
+@pytest.mark.parametrize("complex_", [False, True])
+def test_odd_dimension_gives_zero(n, complex_):
+    matrices = make_skew((4,), n, complex_, seed=n)
+    result = pfaffian_batched(matrices)
+    np.testing.assert_array_equal(result, np.zeros(4, dtype=result.dtype))
+    expected_py = np.array([pf.pfaffian(m) for m in matrices])
+    np.testing.assert_array_equal(result, expected_py)
+
+
+def test_batch_shape_is_preserved():
+    matrices = make_skew((2, 3), 4, complex_=False, seed=1)
+    result = pfaffian_batched(matrices)
+    assert result.shape == (2, 3)
+    expected = np.array([[cpfaffian(m) for m in row] for row in matrices])
+    np.testing.assert_allclose(result, expected, rtol=EPS, atol=EPS)
+
+
+def test_single_matrix_input_gives_scalar():
+    matrix = make_skew((), 4, complex_=False, seed=2)
+    result = pfaffian_batched(matrix)
+    assert np.ndim(result) == 0
+    np.testing.assert_allclose(result, cpfaffian(matrix), rtol=EPS, atol=EPS)
+
+
+def test_empty_batch():
+    matrices = np.empty((0, 4, 4))
+    result = pfaffian_batched(matrices)
+    assert result.shape == (0,)
+    assert result.dtype == np.float64
+
+
+def test_zero_dimensional_matrices():
+    matrices = np.empty((3, 0, 0))
+    np.testing.assert_array_equal(pfaffian_batched(matrices), np.ones(3))
+
+
+@pytest.mark.parametrize("complex_", [False, True])
+def test_layout_resilience(complex_):
+    matrices = make_skew((7,), 8, complex_, seed=3)
+    reference = pfaffian_batched(matrices)
+
+    # Fortran-ordered input
+    matrices_f = np.asfortranarray(matrices)
+    assert not matrices_f.flags["C_CONTIGUOUS"]
+    np.testing.assert_allclose(
+        pfaffian_batched(matrices_f), reference, rtol=EPS, atol=EPS
+    )
+
+    # Non-contiguous strided view
+    padded = np.empty(matrices.shape + (2,), dtype=matrices.dtype)
+    padded[..., 0] = matrices
+    padded[..., 1] = 0
+    view = padded[..., 0]
+    assert not view.flags["C_CONTIGUOUS"]
+    np.testing.assert_allclose(pfaffian_batched(view), reference, rtol=EPS, atol=EPS)
+
+
+def test_input_is_not_modified():
+    matrices = make_skew((4,), 6, complex_=True, seed=4)
+    original = matrices.copy()
+    pfaffian_batched(matrices)
+    np.testing.assert_array_equal(matrices, original)
+
+
+def test_dtype_upcasting():
+    matrices64 = make_skew((5,), 4, complex_=False, seed=5)
+    reference = pfaffian_batched(matrices64)
+
+    result32 = pfaffian_batched(matrices64.astype(np.float32))
+    assert result32.dtype == np.float64
+    np.testing.assert_allclose(result32, reference, rtol=1e-5, atol=1e-5)
+
+    ints = np.array([[[0, 1], [-1, 0]], [[0, -2], [2, 0]]])
+    result_int = pfaffian_batched(ints)
+    assert result_int.dtype == np.float64
+    np.testing.assert_allclose(result_int, [1.0, -2.0], rtol=EPS, atol=EPS)
+
+    cmplx = make_skew((5,), 4, complex_=True, seed=6)
+    result64c = pfaffian_batched(cmplx.astype(np.complex64))
+    assert result64c.dtype == np.complex128
+    np.testing.assert_allclose(result64c, pfaffian_batched(cmplx), rtol=1e-4, atol=1e-4)
+
+    result_list = pfaffian_batched([[[0.0, 1.0], [-1.0, 0.0]]])
+    np.testing.assert_allclose(result_list, [1.0], rtol=EPS, atol=EPS)
+
+
+def test_invalid_shapes_raise():
+    with pytest.raises(InvalidDimensionError):
+        pfaffian_batched(np.zeros(4))  # 1D
+    with pytest.raises(InvalidDimensionError):
+        pfaffian_batched(np.zeros((3, 4, 5)))  # not square
+
+
+def test_invalid_parameters_raise():
+    matrices = make_skew((2,), 4, complex_=False, seed=7)
+    with pytest.raises(InvalidParameterError):
+        pfaffian_batched(matrices, uplo="X")
+    with pytest.raises(InvalidParameterError):
+        pfaffian_batched(matrices, method="X")


### PR DESCRIPTION
## Summary

Ports the batched Pfaffian API from the [jjgoings/pfapack](https://github.com/jjgoings/pfapack) fork (written by @jjgoings) into the upstream meson layout. This adds one public function:

```python
from pfapack.ctypes import pfaffian_batched

matrices = ...  # any (..., N, N)-shaped array, real or complex
pfaffians = pfaffian_batched(matrices, uplo="U", method="P")  # shape (...,)
```

## Why

Upstream only exposes a single-matrix `pfaffian()`, so computing Pfaffians of many small matrices means a Python loop with per-call ctypes overhead and a fresh LAPACK workspace allocation per matrix. The batched kernel allocates the workspace once per batch and loops in C.

**Benchmark** (Apple Silicon, Accelerate; batched vs. Python loop over `ctypes.pfaffian`):

| Workload | Loop | Batched | Speedup |
|---|---|---|---|
| 10,000 × 8×8 real | 51 ms | 3 ms | **~16×** |
| 10,000 × 16×16 real | 62 ms | 9 ms | **~7×** |
| 10,000 × 8×8 complex | 83 ms | 3 ms | **~26×** |

## Implementation notes

This is a **port, not a merge** — the fork diverged before the meson migration, so the code was rewritten into the upstream layout (`original_source/c_interface/skpfa_batched.c`, built into `libcpfapack`).

The fork's 1084-line C file is 12 near-identical entry points; the actual value is two ideas, which this PR keeps in **two entry points (`skpfa_batched_d`, `skpfa_batched_z`, ~260 lines including docs)**:

- **Batch-level workspace reuse**: one workspace query + allocation for the whole batch.
- **Transpose elimination**: row-major (C-order) input is fed directly to the column-major Fortran kernels. PFAPACK then operates on `A^T`, which is handled by swapping `UPLO` and correcting the sign via `pf(A^T) = (−1)^(N/2)·pf(A)`, instead of transposing every matrix.

Deliberately not ported (each was fork-specific plumbing): the 4D variants (the Python wrapper reshapes `(..., N, N)` to a flat batch anyway), the Fortran-layout `_f` variants, and the `with_inverse` variants (~half the file, used only by the fork's AFQMC derivative code — could be a separate PR with its own justification).

Differences from the fork's Python layer:
- Single public function accepting any `(..., N, N)` shape (leading batch shape restored on output; 2D input returns a scalar).
- Errors raised via the existing `pfapack.exceptions` hierarchy (`InvalidDimensionError`, `InvalidParameterError`, `ComputationError`) instead of `RuntimeError`.
- Odd-N matrices return Pfaffian 0 (PFAPACK's native behavior, matching the pure-Python `pfapack.pfaffian.pfaffian`).

## Tests

39 new tests in `tests/test_ctypes_batched.py`:
- Element-wise comparison against single-matrix `ctypes.pfaffian` and pure-Python `pfaffian.pfaffian` for N ∈ {2, 4, 6, 8, 10}, real + complex, both methods — N=6/10 specifically exercise the `(−1)^(N/2)` sign correction where it is negative.
- Layout resilience: F-ordered and non-contiguous strided inputs, float32/complex64/int/list upcasting, input not modified.
- Edge cases: odd N → 0, empty batch, 0×0 matrices → 1, batch-shape preservation, scalar return for 2D input, `uplo="L"`, known values.
- Invalid shapes/parameters raise.

Full suite: 54 passed locally (macOS arm64, Accelerate).

## Credit

The batched implementation is by **Joshua Goings (@jjgoings)** — see the fork and [its PR #6](https://github.com/jjgoings/pfapack/pull/6) describing the optimizations. He is credited as co-author on the commit; review from him would be very welcome.

cc @jjgoings