### PR TITLE
Speed up pfaffian_batched: small-N fast path + workers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ from pfapack.ctypes import pfaffian_batched
 matrices = numpy.random.rand(1000, 8, 8)
 matrices = matrices - matrices.transpose(0, 2, 1)
 pfaffians = pfaffian_batched(matrices)  # shape (1000,)
+
+# Large batches can additionally be spread over multiple threads:
+pfaffians = pfaffian_batched(matrices, workers=-1)  # all cores
 ```
 
 > [!NOTE]

--- a/original_source/c_interface/skpfa_batched.c
+++ b/original_source/c_interface/skpfa_batched.c
@@ -70,11 +70,18 @@
   pf(A^T) = pf(-A) = (-1)^(N/2) pf(A) to correct the sign of the
   result, avoiding an explicit transpose of every matrix in the batch.
 
+  For small matrices (N <= PF_SMALL_N_MAX) and MTHD = 'P', a hand-rolled
+  Parlett-Reid elimination with partial pivoting is used instead of the
+  Fortran kernels. It performs the same algorithm with the same pivoting
+  strategy, but avoids the LAPACK calling machinery (argument checking,
+  workspace logic, BLAS calls), which dominates the runtime at small N.
+
   Ported from the batched implementation by Joshua Goings (@jjgoings),
   https://github.com/jjgoings/pfapack.
 
 ****************************************************************************/
 
+#include <math.h>
 #include <string.h>
 
 #include "commondefs.h"
@@ -82,6 +89,164 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Below this size the hand-rolled Parlett-Reid kernels beat the Fortran
+   path; above it LAPACK's blocked algorithms win. */
+#define PF_SMALL_N_MAX 24
+
+#define A(i, j) a[(size_t)(i) * n + (j)]
+
+/* Expand the UPLO triangle of a row-major skew-symmetric matrix into a
+   full scratch matrix, referencing only that triangle. Writes are kept
+   linear; the mirrored values are read back from the scratch rows
+   already filled, which stay in L1 at these sizes. */
+static void pf_small_fill_d(double *a, const double *src, int n, char uplo)
+{
+    int i, j;
+    if (uplo == 'U') {
+        for (i = 0; i < n; i++) {
+            const double *srow = src + (size_t)i * n;
+            for (j = 0; j < i; j++) A(i, j) = -A(j, i);
+            A(i, i) = 0.0;
+            for (j = i + 1; j < n; j++) A(i, j) = srow[j];
+        }
+    } else {
+        for (i = 0; i < n; i++) {
+            const double *srow = src + (size_t)i * n;
+            for (j = 0; j < i; j++) A(i, j) = srow[j];
+            A(i, i) = 0.0;
+            for (j = i + 1; j < n; j++) A(i, j) = -src[(size_t)j * n + i];
+        }
+    }
+}
+
+/* Parlett-Reid LTL^T elimination with partial pivoting on a full
+   row-major skew-symmetric matrix (destroyed). Mirrors pfaffian_LTL
+   from pfapack/pfaffian.py. N must be even. */
+static double pf_small_d(double *a, int n)
+{
+    double tau[PF_SMALL_N_MAX], col[PF_SMALL_N_MAX];
+    double pfaff = 1.0;
+    int i, j, k;
+
+    for (k = 0; k + 1 < n; k += 2) {
+        /* pivot: largest |A[k+1:, k]| */
+        int kp = k + 1;
+        double mx = fabs(A(k + 1, k));
+        for (i = k + 2; i < n; i++) {
+            double v = fabs(A(i, k));
+            if (v > mx) { mx = v; kp = i; }
+        }
+        if (kp != k + 1) {
+            for (j = k; j < n; j++) {
+                double t = A(k + 1, j); A(k + 1, j) = A(kp, j); A(kp, j) = t;
+            }
+            for (i = k; i < n; i++) {
+                double t = A(i, k + 1); A(i, k + 1) = A(i, kp); A(i, kp) = t;
+            }
+            pfaff = -pfaff;
+        }
+        if (A(k + 1, k) == 0.0) return 0.0;
+        pfaff *= A(k, k + 1);
+        if (k + 2 < n) {
+            /* rank-2 update of the trailing block:
+               A[k+2:,k+2:] += tau (x) col - col (x) tau,
+               tau = A[k, k+2:] / A[k, k+1], col = A[k+2:, k+1] */
+            double inv_piv = 1.0 / A(k, k + 1);
+            for (j = k + 2; j < n; j++) {
+                tau[j] = A(k, j) * inv_piv;
+                col[j] = A(j, k + 1);
+            }
+            for (i = k + 2; i < n; i++) {
+                double ti = tau[i], ci = col[i];
+                double *row = &A(i, 0);
+                for (j = k + 2; j < n; j++)
+                    row[j] += ti * col[j] - ci * tau[j];
+            }
+        }
+    }
+    return pfaff;
+}
+
+/* Complex twin of the above. Needs native complex arithmetic, so it is
+   only available with C99 or C++ complex; the STRUCT_COMPLEX fallback
+   keeps using the Fortran path. */
+#if defined(C99_COMPLEX) || defined(CPLUSPLUS_COMPLEX)
+#define PF_HAVE_SMALL_Z 1
+
+static double pf_small_cabs1(doublecmplx x)
+{
+    return fabs(real(x)) + fabs(imag(x));
+}
+
+static void pf_small_fill_z(doublecmplx *a, const doublecmplx *src, int n,
+                            char uplo)
+{
+    int i, j;
+    if (uplo == 'U') {
+        for (i = 0; i < n; i++) {
+            const doublecmplx *srow = src + (size_t)i * n;
+            for (j = 0; j < i; j++) A(i, j) = -A(j, i);
+            A(i, i) = doublecmplx_zero;
+            for (j = i + 1; j < n; j++) A(i, j) = srow[j];
+        }
+    } else {
+        for (i = 0; i < n; i++) {
+            const doublecmplx *srow = src + (size_t)i * n;
+            for (j = 0; j < i; j++) A(i, j) = srow[j];
+            A(i, i) = doublecmplx_zero;
+            for (j = i + 1; j < n; j++) A(i, j) = -src[(size_t)j * n + i];
+        }
+    }
+}
+
+static doublecmplx pf_small_z(doublecmplx *a, int n)
+{
+    doublecmplx tau[PF_SMALL_N_MAX], col[PF_SMALL_N_MAX];
+    doublecmplx pfaff = doublecmplx_one;
+    int i, j, k;
+
+    for (k = 0; k + 1 < n; k += 2) {
+        int kp = k + 1;
+        double mx = pf_small_cabs1(A(k + 1, k));
+        for (i = k + 2; i < n; i++) {
+            double v = pf_small_cabs1(A(i, k));
+            if (v > mx) { mx = v; kp = i; }
+        }
+        if (kp != k + 1) {
+            for (j = k; j < n; j++) {
+                doublecmplx t = A(k + 1, j);
+                A(k + 1, j) = A(kp, j);
+                A(kp, j) = t;
+            }
+            for (i = k; i < n; i++) {
+                doublecmplx t = A(i, k + 1);
+                A(i, k + 1) = A(i, kp);
+                A(i, kp) = t;
+            }
+            pfaff = -pfaff;
+        }
+        if (mx == 0.0) return doublecmplx_zero;
+        pfaff *= A(k, k + 1);
+        if (k + 2 < n) {
+            doublecmplx inv_piv = doublecmplx_one / A(k, k + 1);
+            for (j = k + 2; j < n; j++) {
+                tau[j] = A(k, j) * inv_piv;
+                col[j] = A(j, k + 1);
+            }
+            for (i = k + 2; i < n; i++) {
+                doublecmplx ti = tau[i], ci = col[i];
+                doublecmplx *row = &A(i, 0);
+                for (j = k + 2; j < n; j++)
+                    row[j] += ti * col[j] - ci * tau[j];
+            }
+        }
+    }
+    return pfaff;
+}
+#endif /* C99_COMPLEX || CPLUSPLUS_COMPLEX */
+
+#undef A
 
 int skpfa_batched_d(int batch_size, int N,
                     const double *A_batch, double *PFAFF_batch,
@@ -100,6 +265,22 @@ int skpfa_batched_d(int batch_size, int N,
 
     if (N == 0) {
         for (i = 0; i < batch_size; i++) PFAFF_batch[i] = 1.0;
+        return 0;
+    }
+
+    if (N % 2 != 0) {
+        for (i = 0; i < batch_size; i++) PFAFF_batch[i] = 0.0;
+        return 0;
+    }
+
+    if (N <= PF_SMALL_N_MAX && mthd == 'P') {
+        double scratch[PF_SMALL_N_MAX * PF_SMALL_N_MAX];
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        for (i = 0; i < batch_size; i++) {
+            pf_small_fill_d(scratch, A_batch + (size_t)i * matrix_elems,
+                            N, uplo);
+            PFAFF_batch[i] = pf_small_d(scratch, N);
+        }
         return 0;
     }
 
@@ -183,6 +364,24 @@ int skpfa_batched_z(int batch_size, int N,
         for (i = 0; i < batch_size; i++) PFAFF_batch[i] = doublecmplx_one;
         return 0;
     }
+
+    if (N % 2 != 0) {
+        for (i = 0; i < batch_size; i++) PFAFF_batch[i] = doublecmplx_zero;
+        return 0;
+    }
+
+#ifdef PF_HAVE_SMALL_Z
+    if (N <= PF_SMALL_N_MAX && mthd == 'P') {
+        doublecmplx scratch[PF_SMALL_N_MAX * PF_SMALL_N_MAX];
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        for (i = 0; i < batch_size; i++) {
+            pf_small_fill_z(scratch, A_batch + (size_t)i * matrix_elems,
+                            N, uplo);
+            PFAFF_batch[i] = pf_small_z(scratch, N);
+        }
+        return 0;
+    }
+#endif
 
     /* Row-major input read as column-major is A^T, whose data lives in
        the opposite triangle; the sign is fixed up after the fact. */

--- a/pfapack/ctypes.py
+++ b/pfapack/ctypes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ctypes
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Final
 
@@ -261,6 +262,7 @@ def pfaffian_batched(
     matrices: np.ndarray,
     uplo: str = "U",
     method: str = "P",
+    workers: int = 1,
 ) -> np.ndarray:
     """Compute the Pfaffian of a batch of skew-symmetric matrices.
 
@@ -281,6 +283,12 @@ def pfaffian_batched(
         If 'U' ('L'), the upper (lower) triangle of each matrix is used.
     method : str
         If 'P' ('H'), the Parley-Reid (Householder) algorithm is used.
+    workers : int
+        Number of threads to spread the batch over. The matrices are
+        independent, so the speedup is roughly linear in the number of
+        physical cores. -1 uses all available cores. Default is 1
+        (serial); leave it at 1 if your application already
+        parallelizes at a higher level.
 
     Returns
     -------
@@ -294,7 +302,7 @@ def pfaffian_batched(
     InvalidDimensionError
         If the input is not an array of square matrices.
     InvalidParameterError
-        If uplo or method parameters are invalid.
+        If uplo, method, or workers parameters are invalid.
     ComputationError
         If the computation fails.
     """
@@ -302,6 +310,12 @@ def pfaffian_batched(
         raise InvalidParameterError(f"'uplo' must be 'U' or 'L', got {uplo!r}")
     if method not in ("P", "H"):
         raise InvalidParameterError(f"'method' must be 'P' or 'H', got {method!r}")
+    if workers == -1:
+        workers = os.cpu_count() or 1
+    if not isinstance(workers, int) or workers < 1:
+        raise InvalidParameterError(
+            f"'workers' must be a positive integer or -1, got {workers!r}"
+        )
 
     matrices = np.asarray(matrices)
     if matrices.ndim < 2 or matrices.shape[-1] != matrices.shape[-2]:
@@ -324,11 +338,34 @@ def pfaffian_batched(
     # Copies only if the dtype or memory layout requires it.
     a = np.ascontiguousarray(matrices, dtype=dtype).reshape(batch_size, n, n)
     pfaffians = np.empty(batch_size, dtype=dtype)
+    uplo_bytes = uplo.encode()
+    method_bytes = method.encode()
 
-    if batch_size > 0:
-        success = func(batch_size, n, a, pfaffians, uplo.encode(), method.encode())
-        if success != 0:
-            raise ComputationError(f"PFAPACK returned error code {success}")
+    def run(start: int, stop: int) -> int:
+        return func(
+            stop - start,
+            n,
+            a[start:stop],
+            pfaffians[start:stop],
+            uplo_bytes,
+            method_bytes,
+        )
+
+    workers = min(workers, batch_size)
+    if workers <= 1:
+        if batch_size > 0:
+            success = run(0, batch_size)
+            if success != 0:
+                raise ComputationError(f"PFAPACK returned error code {success}")
+    else:
+        # ctypes releases the GIL during the C call and every chunk is an
+        # independent contiguous view, so threads scale near-linearly.
+        bounds = np.linspace(0, batch_size, workers + 1, dtype=np.intp)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            results = executor.map(run, bounds[:-1], bounds[1:])
+        for success in results:
+            if success != 0:
+                raise ComputationError(f"PFAPACK returned error code {success}")
 
     # For 2D input batch_shape is (), so this returns a scalar.
     return pfaffians.reshape(batch_shape)[()]

--- a/tests/test_ctypes_batched.py
+++ b/tests/test_ctypes_batched.py
@@ -28,8 +28,9 @@ def make_skew(batch_shape, n, complex_, seed=0):
 
 
 # N=6 and N=10 have odd N/2, exercising the (-1)^(N/2) sign correction
-# of the internal transpose-elimination trick.
-@pytest.mark.parametrize("n", [2, 4, 6, 8, 10])
+# of the internal transpose-elimination trick. N=24/26 sit on either
+# side of the small-N fast-path dispatch threshold.
+@pytest.mark.parametrize("n", [2, 4, 6, 8, 10, 24, 26])
 @pytest.mark.parametrize("complex_", [False, True])
 @pytest.mark.parametrize("method", ["P", "H"])
 def test_matches_single_matrix(n, complex_, method):
@@ -52,6 +53,49 @@ def test_uplo_lower(complex_):
         rtol=EPS,
         atol=EPS,
     )
+
+
+# N=8 takes the small-N fast path, N=32 the Fortran path.
+@pytest.mark.parametrize("n", [8, 32])
+@pytest.mark.parametrize("uplo", ["U", "L"])
+@pytest.mark.parametrize("complex_", [False, True])
+def test_unreferenced_triangle_is_ignored(n, uplo, complex_):
+    matrices = make_skew((5,), n, complex_, seed=8)
+    reference = pfaffian_batched(matrices, uplo=uplo)
+
+    # Poison the triangle that the documentation promises is never read.
+    poisoned = matrices.copy()
+    rows, cols = np.tril_indices(n, k=-1)
+    if uplo == "L":
+        rows, cols = cols, rows
+    poisoned[:, rows, cols] = np.nan
+
+    result = pfaffian_batched(poisoned, uplo=uplo)
+    np.testing.assert_allclose(result, reference, rtol=EPS, atol=EPS)
+
+
+@pytest.mark.parametrize("workers", [2, 8, -1])
+@pytest.mark.parametrize("complex_", [False, True])
+def test_workers_match_serial(workers, complex_):
+    matrices = make_skew((1000,), 8, complex_, seed=9)
+    serial = pfaffian_batched(matrices)
+    threaded = pfaffian_batched(matrices, workers=workers)
+    # Same kernel runs on each chunk, so results are bitwise identical.
+    np.testing.assert_array_equal(threaded, serial)
+
+
+def test_workers_more_than_batch():
+    matrices = make_skew((3,), 4, complex_=False, seed=10)
+    np.testing.assert_array_equal(
+        pfaffian_batched(matrices, workers=16), pfaffian_batched(matrices)
+    )
+
+
+def test_workers_invalid():
+    matrices = make_skew((2,), 4, complex_=False, seed=11)
+    for workers in (0, -2, 1.5):
+        with pytest.raises(InvalidParameterError):
+            pfaffian_batched(matrices, workers=workers)
 
 
 def test_known_values():


### PR DESCRIPTION
## Summary

Stacked on #58 (targets the `add-batched-pfaffian` branch). Two independent optimizations for `pfaffian_batched`, both producing **identical results** to the base implementation:

### 1. Small-N fast path (C)

At small N, most of the per-matrix time is LAPACK calling machinery (argument checks, workspace logic, BLAS calls), not math. For **N ≤ 24 with `method="P"`**, the kernel now dispatches to a hand-rolled Parlett–Reid elimination with partial pivoting — the same algorithm and pivoting strategy as the pure-Python `pfaffian_LTL`, in ~70 lines of C. Above the threshold the blocked LAPACK path wins decisively (it is ~3× faster by N=64), so it is kept.

Serial per-matrix times (Apple M-series, min over reps, lightly loaded):

| N | #58 (Fortran path) | fast path | speedup |
|---|---|---|---|
| 2 | 58 ns | 10 ns | 5.8× |
| 4 | 111 ns | 46 ns | 2.4× |
| **8** | **286 ns** | **172 ns** | **1.7×** |
| 12 | 518 ns | 335 ns | 1.5× |
| 16 | 796 ns | 566 ns | 1.4× |
| 24 | 1545 ns | 1233 ns | 1.25× |

The fast path rebuilds the full matrix from the `uplo` triangle into scratch (linear writes, mirrored reads stay in L1), preserving the documented guarantee that the other triangle is never referenced — there is a NaN-poisoning test for this on both sides of the dispatch threshold.

### 2. `workers=` keyword (Python)

```python
pfaffian_batched(matrices, workers=-1)  # all cores
```

Matrices in a batch are independent, ctypes releases the GIL during the C call, and chunk slices are contiguous views — so a `ThreadPoolExecutor` over chunks scales near-linearly with physical cores with no C changes and no extra copies. Measured **4–7.6×** on large batches (16-core machine, idle); default stays `workers=1` so applications that already parallelize at a higher level are unaffected. Results are bitwise identical across worker counts (same kernel per chunk).

Combined, the AFQMC-scale workload (262144 × 8×8) drops from ~77 ms (#58) to ~10–20 ms, on top of #58's 16–26× over a Python loop.

## Notes

- Odd-N batches now short-circuit to zeros in C (same result as before, without calling Fortran).
- The complex fast path needs native complex arithmetic, so it's compiled for C99/C++ complex; the `STRUCT_COMPLEX` fallback keeps using the Fortran path. The real fast path is unconditional.
- `method="H"` always routes to the Fortran path.

## Tests

24 new tests (63 total for the batched interface, full suite 78 passed):
- `test_matches_single_matrix` extended with N=24/26 to cover both sides of the dispatch threshold (real + complex, both methods).
- NaN-poisoned unreferenced triangle: both `uplo` values, both dtypes, fast path (N=8) and Fortran path (N=32).
- `workers`: bitwise equality with serial for `workers ∈ {2, 8, -1}`, batch smaller than worker count, invalid values raise `InvalidParameterError`.